### PR TITLE
Reduce allocations and expensive operations parsing yaml

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -6,6 +6,9 @@
     </properties>
     <body>
         <release version="2.3" date="in GIT" description="Maintenance">
+            <action dev="maslovalex" type="fix" issue="1096">
+                Implement the merge tag in the Node graph (thanks to Floris Westerman)
+            </action>
             <action dev="asomov" type="update" issue="1090">
                 Try to keep the anchor name when available (thanks to Gergely Czuczy)
             </action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -6,6 +6,9 @@
     </properties>
     <body>
         <release version="2.3" date="in GIT" description="Maintenance">
+            <action dev="maslovalex" type="add">
+                Add possibility to create JMH benchmark (thank to David Schlosnagle)
+            </action>
             <action dev="maslovalex" type="fix" issue="1096">
                 Implement the merge tag in the Node graph (thanks to Floris Westerman)
             </action>

--- a/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
+++ b/src/main/java/org/yaml/snakeyaml/LoaderOptions.java
@@ -38,6 +38,8 @@ public class LoaderOptions {
 
   private int codePointLimit = 3 * 1024 * 1024; // 3 MB
 
+  private boolean mergeOnCompose = false;
+
   /**
    * Secure by default - no custom classes are allowed
    */
@@ -206,6 +208,19 @@ public class LoaderOptions {
     this.codePointLimit = codePointLimit;
   }
 
+  public boolean isMergeOnCompose() {
+    return mergeOnCompose;
+  }
+
+  /**
+   * Process merge tags on Compose stage.
+   *
+   * @param mergeOnCompose - <code>true</code> to process merge tags while composing nodes
+   */
+  public void setMergeOnCompose(boolean mergeOnCompose) {
+    this.mergeOnCompose = mergeOnCompose;
+  }
+
   public TagInspector getTagInspector() {
     return tagInspector;
   }
@@ -213,4 +228,5 @@ public class LoaderOptions {
   public void setTagInspector(TagInspector tagInspector) {
     this.tagInspector = tagInspector;
   }
+
 }

--- a/src/main/java/org/yaml/snakeyaml/Yaml.java
+++ b/src/main/java/org/yaml/snakeyaml/Yaml.java
@@ -86,6 +86,16 @@ public class Yaml {
   /**
    * Create Yaml instance.
    *
+   * @param loadingConfig LoadingConfig to control load behavior
+   * @param dumperOptions DumperOptions to configure outgoing objects
+   */
+  public Yaml(LoaderOptions loadingConfig, DumperOptions dumperOptions) {
+    this(new Constructor(loadingConfig), new Representer(dumperOptions), dumperOptions);
+  }
+
+  /**
+   * Create Yaml instance.
+   *
    * @param representer Representer to emit outgoing objects. The DumperOptions may not be fully
    *        respected. It is better to use explicit DumperOptions.
    * @deprecated use method with explicit DumperOptions

--- a/src/main/java/org/yaml/snakeyaml/composer/Composer.java
+++ b/src/main/java/org/yaml/snakeyaml/composer/Composer.java
@@ -188,8 +188,7 @@ public class Composer {
       AliasEvent event = (AliasEvent) parser.getEvent();
       String anchor = event.getAnchor();
       if (!anchors.containsKey(anchor)) {
-        throw new ComposerException(null, null, "found undefined alias " + anchor,
-            event.getStartMark());
+        throw new ComposerException("found undefined alias " + anchor, event.getStartMark());
       }
       node = anchors.get(anchor);
       if (!(node instanceof ScalarNode)) {
@@ -237,8 +236,7 @@ public class Composer {
       nodeTag = new Tag(tag);
       if (nodeTag.isCustomGlobal()
           && !loadingConfig.getTagInspector().isGlobalTagAllowed(nodeTag)) {
-        throw new ComposerException(null, null, "Global tag is not allowed: " + tag,
-            ev.getStartMark());
+        throw new ComposerException("Global tag is not allowed: " + tag, ev.getStartMark());
       }
     }
     Node node = new ScalarNode(nodeTag, resolved, ev.getValue(), ev.getStartMark(), ev.getEndMark(),
@@ -265,8 +263,7 @@ public class Composer {
       nodeTag = new Tag(tag);
       if (nodeTag.isCustomGlobal()
           && !loadingConfig.getTagInspector().isGlobalTagAllowed(nodeTag)) {
-        throw new ComposerException(null, null, "Global tag is not allowed: " + tag,
-            startEvent.getStartMark());
+        throw new ComposerException("Global tag is not allowed: " + tag, startEvent.getStartMark());
       }
     }
     final ArrayList<Node> children = new ArrayList<Node>();
@@ -310,8 +307,7 @@ public class Composer {
       nodeTag = new Tag(tag);
       if (nodeTag.isCustomGlobal()
           && !loadingConfig.getTagInspector().isGlobalTagAllowed(nodeTag)) {
-        throw new ComposerException(null, null, "Global tag is not allowed: " + tag,
-            startEvent.getStartMark());
+        throw new ComposerException("Global tag is not allowed: " + tag, startEvent.getStartMark());
       }
     }
 
@@ -375,9 +371,9 @@ public class Composer {
         return (MappingNode) ref;
       }
     }
-    // TODO: add corrrect marks to the exception
-    throw new ComposerException("Expected mapping node or an anchor referencing mapping", null,
-        null, null);
+    Event ev = parser.peekEvent();
+    throw new ComposerException("Expected mapping node or an anchor referencing mapping",
+        ev.getStartMark());
   }
 
   /**

--- a/src/main/java/org/yaml/snakeyaml/composer/Composer.java
+++ b/src/main/java/org/yaml/snakeyaml/composer/Composer.java
@@ -317,14 +317,12 @@ public class Composer {
       node.setAnchor(anchor);
       anchors.put(anchor, node);
     }
-    boolean hasMerges = false;
     while (!parser.checkEvent(Event.ID.MappingEnd)) {
       blockCommentsCollector.collectEvents();
       if (parser.checkEvent(Event.ID.MappingEnd)) {
         break;
       }
       composeMappingChildren(children, node);
-      hasMerges = hasMerges || node.isMerged();
     }
     if (startEvent.isFlow()) {
       node.setInLineComments(inlineCommentsCollector.collectEvents().consume());
@@ -336,9 +334,10 @@ public class Composer {
       node.setInLineComments(inlineCommentsCollector.consume());
     }
 
-    if (loadingConfig.isMergeOnCompose() && hasMerges) {
+    if (loadingConfig.isMergeOnCompose() && node.isMerged()) {
       List<NodeTuple> updatedValue = flatten(node);
       node.setValue(updatedValue);
+      node.setMerged(false);
     }
 
     return node;

--- a/src/main/java/org/yaml/snakeyaml/composer/ComposerException.java
+++ b/src/main/java/org/yaml/snakeyaml/composer/ComposerException.java
@@ -24,7 +24,7 @@ public class ComposerException extends MarkedYAMLException {
   private static final long serialVersionUID = 2146314636913113935L;
 
   /**
-   * Create
+   * Create exception when context is available
    *
    * @param context - context
    * @param contextMark - mark
@@ -33,5 +33,15 @@ public class ComposerException extends MarkedYAMLException {
    */
   protected ComposerException(String context, Mark contextMark, String problem, Mark problemMark) {
     super(context, contextMark, problem, problemMark);
+  }
+
+  /**
+   * Create exception without a context
+   *
+   * @param problem - the issue
+   * @param problemMark - where the issue occurs
+   */
+  protected ComposerException(String problem, Mark problemMark) {
+    this(null, null, problem, problemMark);
   }
 }

--- a/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/BaseConstructor.java
@@ -44,6 +44,7 @@ import org.yaml.snakeyaml.nodes.NodeTuple;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.util.Tuple;
 
 /**
  * Base code
@@ -80,8 +81,8 @@ public abstract class BaseConstructor {
   protected Composer composer;
   final Map<Node, Object> constructedObjects;
   private final Set<Node> recursiveObjects;
-  private final ArrayList<RecursiveTuple<Map<Object, Object>, RecursiveTuple<Object, Object>>> maps2fill;
-  private final ArrayList<RecursiveTuple<Set<Object>, Object>> sets2fill;
+  private final ArrayList<Tuple<Map<Object, Object>, Tuple<Object, Object>>> maps2fill;
+  private final ArrayList<Tuple<Set<Object>, Object>> sets2fill;
 
   /**
    * the tag for the root node
@@ -119,9 +120,8 @@ public abstract class BaseConstructor {
     }
     constructedObjects = new HashMap<Node, Object>();
     recursiveObjects = new HashSet<Node>();
-    maps2fill =
-        new ArrayList<RecursiveTuple<Map<Object, Object>, RecursiveTuple<Object, Object>>>();
-    sets2fill = new ArrayList<RecursiveTuple<Set<Object>, Object>>();
+    maps2fill = new ArrayList<Tuple<Map<Object, Object>, Tuple<Object, Object>>>();
+    sets2fill = new ArrayList<Tuple<Set<Object>, Object>>();
     typeDefinitions = new HashMap<Class<? extends Object>, TypeDescription>();
     typeTags = new HashMap<Tag, Class<? extends Object>>();
 
@@ -219,14 +219,14 @@ public abstract class BaseConstructor {
    */
   private void fillRecursive() {
     if (!maps2fill.isEmpty()) {
-      for (RecursiveTuple<Map<Object, Object>, RecursiveTuple<Object, Object>> entry : maps2fill) {
-        RecursiveTuple<Object, Object> key_value = entry._2();
+      for (Tuple<Map<Object, Object>, Tuple<Object, Object>> entry : maps2fill) {
+        Tuple<Object, Object> key_value = entry._2();
         entry._1().put(key_value._1(), key_value._2());
       }
       maps2fill.clear();
     }
     if (!sets2fill.isEmpty()) {
-      for (RecursiveTuple<Set<Object>, Object> value : sets2fill) {
+      for (Tuple<Set<Object>, Object> value : sets2fill) {
         value._1().add(value._2());
       }
       sets2fill.clear();
@@ -593,7 +593,7 @@ public abstract class BaseConstructor {
    * not observe key hashCode changes.
    */
   protected void postponeMapFilling(Map<Object, Object> mapping, Object key, Object value) {
-    maps2fill.add(0, new RecursiveTuple(mapping, new RecursiveTuple(key, value)));
+    maps2fill.add(0, new Tuple(mapping, new Tuple(key, value)));
   }
 
   protected void constructSet2ndStep(MappingNode node, Set<Object> set) {
@@ -623,7 +623,7 @@ public abstract class BaseConstructor {
    * does not observe value hashCode changes.
    */
   protected void postponeSetFilling(Set<Object> set, Object key) {
-    sets2fill.add(0, new RecursiveTuple<Set<Object>, Object>(set, key));
+    sets2fill.add(0, new Tuple<Set<Object>, Object>(set, key));
   }
 
   public void setPropertyUtils(PropertyUtils propertyUtils) {
@@ -658,25 +658,6 @@ public abstract class BaseConstructor {
     typeTags.put(tag, definition.getType());
     definition.setPropertyUtils(getPropertyUtils());
     return typeDefinitions.put(definition.getType(), definition);
-  }
-
-  private static class RecursiveTuple<T, K> {
-
-    private final T _1;
-    private final K _2;
-
-    public RecursiveTuple(T _1, K _2) {
-      this._1 = _1;
-      this._2 = _2;
-    }
-
-    public K _2() {
-      return _2;
-    }
-
-    public T _1() {
-      return _1;
-    }
   }
 
   public final boolean isExplicitPropertyUtils() {

--- a/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
@@ -251,7 +251,7 @@ public class SafeConstructor extends BaseConstructor {
 
     @Override
     public Object construct(Node node) {
-      String value = constructScalar((ScalarNode) node).replaceAll("_", "");
+      String value = constructScalar((ScalarNode) node).replace("_", "");
       if (value.isEmpty()) {
         throw new ConstructorException("while constructing an int", node.getStartMark(),
             "found empty value", node.getStartMark());

--- a/src/main/java/org/yaml/snakeyaml/parser/ParserImpl.java
+++ b/src/main/java/org/yaml/snakeyaml/parser/ParserImpl.java
@@ -240,7 +240,7 @@ public class ParserImpl implements Parser {
         Mark startMark = token.getStartMark();
         VersionTagsTuple tuple = processDirectives();
         while (scanner.checkToken(Token.ID.Comment)) {
-          // TODO: till we figure out what todo with the comments
+          // the comments in the directive are ignored because they are not part of the Node tree
           scanner.getToken();
         }
         if (!scanner.checkToken(Token.ID.StreamEnd)) {

--- a/src/main/java/org/yaml/snakeyaml/serializer/Serializer.java
+++ b/src/main/java/org/yaml/snakeyaml/serializer/Serializer.java
@@ -98,8 +98,8 @@ public final class Serializer {
         if (node instanceof MappingNode) {
           return (MappingNode) node;
         }
-        // TODO: This need to be explored more to understand if only MappingNode possible.Or at
-        // least message need to be improved.
+        // TODO: This need to be explored more to understand if only MappingNode possible.
+        // Or at least the error message needs to be improved.
         throw new SerializerException("expecting MappingNode while processing merge.");
       }
     };

--- a/src/main/java/org/yaml/snakeyaml/serializer/Serializer.java
+++ b/src/main/java/org/yaml/snakeyaml/serializer/Serializer.java
@@ -47,6 +47,7 @@ import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.resolver.Resolver;
+import org.yaml.snakeyaml.util.MergeUtils;
 
 public final class Serializer {
 
@@ -63,6 +64,8 @@ public final class Serializer {
   private final Tag explicitRoot;
   private final boolean dereferenceAliases;
   private final Set<Node> recursive;
+
+  private final MergeUtils mergeUtils;
 
   public Serializer(Emitable emitter, Resolver resolver, DumperOptions opts, Tag rootTag) {
     if (emitter == null) {
@@ -89,6 +92,17 @@ public final class Serializer {
     this.recursive = Collections.newSetFromMap(new IdentityHashMap<Node, Boolean>());
     this.closed = null;
     this.explicitRoot = rootTag;
+
+    mergeUtils = new MergeUtils() {
+      public MappingNode asMappingNode(Node node) {
+        if (node instanceof MappingNode) {
+          return (MappingNode) node;
+        }
+        // TODO: This need to be explored more to understand if only MappingNode possible.Or at
+        // least message need to be improved.
+        throw new SerializerException("expecting MappingNode while processing merge.");
+      }
+    };
   }
 
   public void open() throws IOException {
@@ -214,11 +228,16 @@ public final class Serializer {
           break;
         default:// instance of MappingNode
           serializeComments(node.getBlockComments());
-          Tag implicitTag = this.resolver.resolve(NodeId.mapping, null, true);
-          boolean implicitM = node.getTag().equals(implicitTag);
-          MappingNode mnode = (MappingNode) node;
-          List<NodeTuple> map = mnode.getValue();
-          if (mnode.getTag() != Tag.COMMENT) {
+          if (node.getTag() != Tag.COMMENT) {
+            Tag implicitTag = this.resolver.resolve(NodeId.mapping, null, true);
+            boolean implicitM = node.getTag().equals(implicitTag);
+            MappingNode mnode = (MappingNode) node;
+            List<NodeTuple> map = mnode.getValue();
+
+            if (this.dereferenceAliases && mnode.isMerged()) {
+              map = mergeUtils.flatten(mnode);
+            }
+
             this.emitter.emit(new MappingStartEvent(tAlias, mnode.getTag().getValue(), implicitM,
                 null, null, mnode.getFlowStyle()));
             for (NodeTuple row : map) {

--- a/src/main/java/org/yaml/snakeyaml/util/MergeUtils.java
+++ b/src/main/java/org/yaml/snakeyaml/util/MergeUtils.java
@@ -25,6 +25,9 @@ import org.yaml.snakeyaml.nodes.ScalarNode;
 import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
+/**
+ * Utility to enable Node merging
+ */
 public abstract class MergeUtils {
 
   abstract public MappingNode asMappingNode(Node node);
@@ -88,5 +91,4 @@ public abstract class MergeUtils {
     }
     return new Tuple<>(result, keys);
   }
-
 }

--- a/src/main/java/org/yaml/snakeyaml/util/MergeUtils.java
+++ b/src/main/java/org/yaml/snakeyaml/util/MergeUtils.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2008, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.yaml.snakeyaml.util;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.SequenceNode;
+import org.yaml.snakeyaml.nodes.Tag;
+
+public abstract class MergeUtils {
+
+  abstract public MappingNode asMappingNode(Node node);
+
+  public List<NodeTuple> flatten(MappingNode node) {
+    List<NodeTuple> original = node.getValue();
+    Set<String> keys = new HashSet<>(original.size());
+    List<NodeTuple> updated = new ArrayList<>(original.size());
+    List<NodeTuple> merges = new ArrayList<>(2);
+
+    for (NodeTuple tuple : original) {
+      Node keyNode = tuple.getKeyNode();
+      if (keyNode.getTag().equals(Tag.MERGE)) {
+        merges.add(tuple);
+      } else {
+        updated.add(tuple);
+        if (keyNode instanceof ScalarNode) {
+          ScalarNode sNode = (ScalarNode) keyNode;
+          keys.add(sNode.getValue());
+        }
+      }
+    }
+
+    for (NodeTuple tuple : merges) {
+      Node valueNode = tuple.getValueNode();
+      if (valueNode instanceof SequenceNode) {
+        SequenceNode seqNode = (SequenceNode) valueNode;
+        for (Node ref : seqNode.getValue()) {
+          MappingNode mergable = asMappingNode(ref);
+          Tuple<List<NodeTuple>, Set<String>> filtered = filter(mergable.getValue(), keys);
+          updated.addAll(filtered._1());
+          keys.addAll(filtered._2());
+        }
+      } else {
+        MappingNode mergable = asMappingNode(valueNode);
+        Tuple<List<NodeTuple>, Set<String>> filtered = filter(mergable.getValue(), keys);
+        updated.addAll(filtered._1());
+        keys.addAll(filtered._2());
+      }
+    }
+    return updated;
+  }
+
+  private Tuple<List<NodeTuple>, Set<String>> filter(List<NodeTuple> mergables,
+      Set<String> filter) {
+    int size = mergables.size();
+    Set<String> keys = new HashSet<>(size);
+    List<NodeTuple> result = new ArrayList<>(size);
+    for (NodeTuple tuple : mergables) {
+      Node key = tuple.getKeyNode();
+      if (key instanceof ScalarNode) {
+        ScalarNode sNode = (ScalarNode) key;
+        String nodeValue = sNode.getValue();
+        if (!filter.contains(nodeValue)) {
+          result.add(tuple);
+          keys.add(nodeValue);
+        }
+      } else {
+        result.add(tuple);
+      }
+    }
+    return new Tuple<>(result, keys);
+  }
+
+}

--- a/src/main/java/org/yaml/snakeyaml/util/MergeUtils.java
+++ b/src/main/java/org/yaml/snakeyaml/util/MergeUtils.java
@@ -30,6 +30,11 @@ import org.yaml.snakeyaml.nodes.Tag;
  */
 public abstract class MergeUtils {
 
+  /**
+   * Transform the provided Node into MappingNode in Composer or Serializer
+   * @param node - the node to flatten
+   * @return node or its reference to proceed with flatten
+   */
   abstract public MappingNode asMappingNode(Node node);
 
   public List<NodeTuple> flatten(MappingNode node) {

--- a/src/main/java/org/yaml/snakeyaml/util/Tuple.java
+++ b/src/main/java/org/yaml/snakeyaml/util/Tuple.java
@@ -1,0 +1,20 @@
+package org.yaml.snakeyaml.util;
+
+public final class Tuple<T, K> {
+
+  private final T _1;
+  private final K _2;
+
+  public Tuple(T _1, K _2) {
+    this._1 = _1;
+    this._2 = _2;
+  }
+
+  public K _2() {
+    return _2;
+  }
+
+  public T _1() {
+    return _1;
+  }
+}

--- a/src/main/java/org/yaml/snakeyaml/util/Tuple.java
+++ b/src/main/java/org/yaml/snakeyaml/util/Tuple.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) 2008, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.yaml.snakeyaml.util;
 
 public final class Tuple<T, K> {

--- a/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeExpandTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeExpandTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2008, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.yaml.snakeyaml.issues.issue1096;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import org.junit.Test;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Util;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Node;
+
+public class MergeExpandTest {
+
+  @Test
+  public void simple_load_Merge() {
+    String str = Util.getLocalResource("issues/issue1096-simple-merge-input.yaml");
+    String expected = Util.getLocalResource("issues/issue1096-simple-merge-output.yaml");
+
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setMergeOnCompose(true);
+
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDereferenceAliases(true);
+
+    Yaml yaml = new Yaml(loaderOptions, dumperOptions);
+    Node sourceTree = yaml.compose(new StringReader(str));
+
+    StringWriter writer = new StringWriter();
+    yaml.serialize(sourceTree, writer);
+    String out = writer.toString();
+
+    assertEquals(expected, out);
+  }
+
+  @Test
+  public void specs_load_Merge() {
+    String str = Util.getLocalResource("issues/issue1096-merge-input.yaml");
+    String expected = Util.getLocalResource("issues/issue1096-merge-output.yaml");
+
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setProcessComments(false);
+    loaderOptions.setMergeOnCompose(true);
+
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDereferenceAliases(true);
+
+    Yaml yaml = new Yaml(loaderOptions, dumperOptions);
+    Node sourceTree = yaml.compose(new StringReader(str));
+
+    StringWriter writer = new StringWriter();
+    yaml.serialize(sourceTree, writer);
+    String out = writer.toString();
+
+    assertEquals(expected, out);
+  }
+
+  @Test
+  public void merge_As_Scalar() {
+    String str =
+        "test-list:\n" + " - &1\n" + "   a: 1\n" + "   b: 2\n" + " - &2 <<: *1\n" + " - <<: *2";
+
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setProcessComments(false);
+    loaderOptions.setMergeOnCompose(true);
+
+    Yaml yaml = new Yaml(loaderOptions);
+    try {
+      yaml.compose(new StringReader(str));
+      fail();
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Expected mapping node or an anchor referencing mapping"));
+    }
+
+  }
+
+
+
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnComposeTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnComposeTest.java
@@ -51,6 +51,27 @@ public class MergeOnComposeTest {
   }
 
   @Test
+  public void complex_load_Merge() {
+    String str = Util.getLocalResource("issues/issue1096-complex-merge-input.yaml");
+    String expected = Util.getLocalResource("issues/issue1096-complex-merge-output.yaml");
+
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setMergeOnCompose(true);
+
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDereferenceAliases(true);
+
+    Yaml yaml = new Yaml(loaderOptions, dumperOptions);
+    Node sourceTree = yaml.compose(new StringReader(str));
+
+    StringWriter writer = new StringWriter();
+    yaml.serialize(sourceTree, writer);
+    String out = writer.toString();
+
+    assertEquals(expected, out);
+  }
+
+  @Test
   public void specs_load_Merge() {
     String str = Util.getLocalResource("issues/issue1096-merge-input.yaml");
     String expected = Util.getLocalResource("issues/issue1096-merge-output.yaml");

--- a/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnComposeTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnComposeTest.java
@@ -86,11 +86,9 @@ public class MergeOnComposeTest {
       yaml.compose(new StringReader(str));
       fail();
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Expected mapping node or an anchor referencing mapping"));
+      String error = e.getMessage();
+      assertTrue(error, error.contains("Expected mapping node or an anchor referencing mapping"));
+      assertTrue(error, error.contains("in 'reader', line 6, column 10:"));
     }
-
   }
-
-
-
 }

--- a/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnComposeTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnComposeTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2008, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.yaml.snakeyaml.issues.issue1096;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import org.junit.Test;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Util;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.nodes.Node;
+
+public class MergeOnComposeTest {
+
+  @Test
+  public void simple_load_Merge() {
+    String str = Util.getLocalResource("issues/issue1096-simple-merge-input.yaml");
+    String expected = Util.getLocalResource("issues/issue1096-simple-merge-output.yaml");
+
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setMergeOnCompose(true);
+
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDereferenceAliases(true);
+
+    Yaml yaml = new Yaml(loaderOptions, dumperOptions);
+    Node sourceTree = yaml.compose(new StringReader(str));
+
+    StringWriter writer = new StringWriter();
+    yaml.serialize(sourceTree, writer);
+    String out = writer.toString();
+
+    assertEquals(expected, out);
+  }
+
+  @Test
+  public void specs_load_Merge() {
+    String str = Util.getLocalResource("issues/issue1096-merge-input.yaml");
+    String expected = Util.getLocalResource("issues/issue1096-merge-output.yaml");
+
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setProcessComments(false);
+    loaderOptions.setMergeOnCompose(true);
+
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDereferenceAliases(true);
+
+    Yaml yaml = new Yaml(loaderOptions, dumperOptions);
+    Node sourceTree = yaml.compose(new StringReader(str));
+
+    StringWriter writer = new StringWriter();
+    yaml.serialize(sourceTree, writer);
+    String out = writer.toString();
+
+    assertEquals(expected, out);
+  }
+
+  @Test
+  public void merge_As_Scalar() {
+    String str =
+        "test-list:\n" + " - &1\n" + "   a: 1\n" + "   b: 2\n" + " - &2 <<: *1\n" + " - <<: *2";
+
+    LoaderOptions loaderOptions = new LoaderOptions();
+    loaderOptions.setProcessComments(false);
+    loaderOptions.setMergeOnCompose(true);
+
+    Yaml yaml = new Yaml(loaderOptions);
+    try {
+      yaml.compose(new StringReader(str));
+      fail();
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Expected mapping node or an anchor referencing mapping"));
+    }
+
+  }
+
+
+
+}

--- a/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnSerializeTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnSerializeTest.java
@@ -27,42 +27,35 @@ import org.yaml.snakeyaml.Util;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Node;
 
-public class MergeExpandTest {
+public class MergeOnSerializeTest {
 
   @Test
-  public void simple_load_Merge() {
+  public void simple_Merge() {
     String str = Util.getLocalResource("issues/issue1096-simple-merge-input.yaml");
     String expected = Util.getLocalResource("issues/issue1096-simple-merge-output.yaml");
 
-    LoaderOptions loaderOptions = new LoaderOptions();
-    loaderOptions.setMergeOnCompose(true);
-
     DumperOptions dumperOptions = new DumperOptions();
     dumperOptions.setDereferenceAliases(true);
 
-    Yaml yaml = new Yaml(loaderOptions, dumperOptions);
+    Yaml yaml = new Yaml(dumperOptions);
     Node sourceTree = yaml.compose(new StringReader(str));
 
     StringWriter writer = new StringWriter();
     yaml.serialize(sourceTree, writer);
     String out = writer.toString();
-
     assertEquals(expected, out);
   }
 
+
   @Test
-  public void specs_load_Merge() {
+  public void specs_Merge() {
     String str = Util.getLocalResource("issues/issue1096-merge-input.yaml");
     String expected = Util.getLocalResource("issues/issue1096-merge-output.yaml");
 
-    LoaderOptions loaderOptions = new LoaderOptions();
-    loaderOptions.setProcessComments(false);
-    loaderOptions.setMergeOnCompose(true);
-
     DumperOptions dumperOptions = new DumperOptions();
     dumperOptions.setDereferenceAliases(true);
 
-    Yaml yaml = new Yaml(loaderOptions, dumperOptions);
+    Yaml yaml = new Yaml(dumperOptions);
     Node sourceTree = yaml.compose(new StringReader(str));
 
     StringWriter writer = new StringWriter();
@@ -71,6 +64,7 @@ public class MergeExpandTest {
 
     assertEquals(expected, out);
   }
+
 
   @Test
   public void merge_As_Scalar() {

--- a/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnSerializeTest.java
+++ b/src/test/java/org/yaml/snakeyaml/issues/issue1096/MergeOnSerializeTest.java
@@ -46,6 +46,23 @@ public class MergeOnSerializeTest {
     assertEquals(expected, out);
   }
 
+  @Test
+  public void complex_Merge() {
+    String str = Util.getLocalResource("issues/issue1096-complex-merge-input.yaml");
+    String expected = Util.getLocalResource("issues/issue1096-complex-merge-output.yaml");
+
+    DumperOptions dumperOptions = new DumperOptions();
+    dumperOptions.setDereferenceAliases(true);
+
+    Yaml yaml = new Yaml(dumperOptions);
+    Node sourceTree = yaml.compose(new StringReader(str));
+
+    StringWriter writer = new StringWriter();
+    yaml.serialize(sourceTree, writer);
+    String out = writer.toString();
+    assertEquals(expected, out);
+  }
+
 
   @Test
   public void specs_Merge() {

--- a/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
+++ b/src/test/java/org/yaml/snakeyaml/jmh/ParseBenchmark.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2024, SnakeYAML
+/**
+ * Copyright (c) 2008, SnakeYAML
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/resources/issues/issue1096-complex-merge-input.yaml
+++ b/src/test/resources/issues/issue1096-complex-merge-input.yaml
@@ -1,0 +1,28 @@
+.input: &anchor
+  foo: first
+.input-2: &anchor2
+  <<: *anchor
+  bar: 0
+.input-3: &anchor3
+  <<: *anchor2
+simple:
+  <<: *anchor
+  bar: 123
+complex:
+  <<: *anchor
+  foo: override
+  bar: 234
+complex-2:
+  foo: none
+  <<: *anchor
+  bar: 123
+double:
+  <<: *anchor2
+double-2:
+  <<: *anchor2
+  bar: 999
+tripple:
+  <<: *anchor3
+tripple-2:
+  <<: *anchor3
+  foo: tripplet

--- a/src/test/resources/issues/issue1096-complex-merge-output.yaml
+++ b/src/test/resources/issues/issue1096-complex-merge-output.yaml
@@ -1,0 +1,29 @@
+.input:
+  foo: first
+.input-2:
+  bar: 0
+  foo: first
+.input-3:
+  bar: 0
+  foo: first
+simple:
+  bar: 123
+  foo: first
+complex:
+  foo: override
+  bar: 234
+complex-2:
+  foo: none
+  bar: 123
+double:
+  bar: 0
+  foo: first
+double-2:
+  bar: 999
+  foo: first
+tripple:
+  bar: 0
+  foo: first
+tripple-2:
+  foo: tripplet
+  bar: 0

--- a/src/test/resources/issues/issue1096-merge-input.yaml
+++ b/src/test/resources/issues/issue1096-merge-input.yaml
@@ -1,0 +1,26 @@
+- &CENTER { x: 1, y: 2 }
+- &LEFT { x: 0, y: 2 }
+- &BIG { r: 10 }
+- &SMALL { r: 1 }
+
+# All the following maps are equal:
+
+- # Explicit keys
+  x: 1
+  y: 2
+  r: 10
+  label: center/big
+
+- # Merge one map
+  << : *CENTER
+  r: 10
+  label: center/big
+
+- # Merge multiple maps
+  << : [ *CENTER, *BIG ]
+  label: center/big
+
+- # Override
+  << : [ *BIG, *LEFT, *SMALL ]
+  x: 1
+  label: center/big

--- a/src/test/resources/issues/issue1096-merge-output.yaml
+++ b/src/test/resources/issues/issue1096-merge-output.yaml
@@ -1,0 +1,20 @@
+- {x: 1, y: 2}
+- {x: 0, y: 2}
+- {r: 10}
+- {r: 1}
+- x: 1
+  y: 2
+  r: 10
+  label: center/big
+- r: 10
+  label: center/big
+  x: 1
+  y: 2
+- label: center/big
+  x: 1
+  y: 2
+  r: 10
+- x: 1
+  label: center/big
+  r: 10
+  y: 2

--- a/src/test/resources/issues/issue1096-simple-merge-input.yaml
+++ b/src/test/resources/issues/issue1096-simple-merge-input.yaml
@@ -1,0 +1,13 @@
+.input: &anchor
+  foo: first
+simple:
+  <<: *anchor
+  bar: 123
+complex:
+  <<: *anchor
+  foo: override
+  bar: 234
+complex-2:
+  foo: none
+  <<: *anchor
+  bar: 123

--- a/src/test/resources/issues/issue1096-simple-merge-output.yaml
+++ b/src/test/resources/issues/issue1096-simple-merge-output.yaml
@@ -1,0 +1,11 @@
+.input:
+  foo: first
+simple:
+  bar: 123
+  foo: first
+complex:
+  foo: override
+  bar: 234
+complex-2:
+  foo: none
+  bar: 123


### PR DESCRIPTION
`ParseBenchmark` shows between ~10% and ~20% speedup by removing allocations, GC overhead, and CPU work.

* `SafeConstructor#construct(Node)` uses `String#replace(String, String)` character replace to avoid expensive regex compilation and replacement when removing underscore character. This operation additionally may make use of vectorized `String#indexOf` on x64 & aarch64 to search for replacements.
* `ScannerImpl` `scanFlow*` methods append directly to existing `StringBuilder` instance to avoid allocating new `StringBuilder` and constructing intermediate `String`s.

Before
```
Benchmark             (entries)  Mode  Cnt    Score    Error  Units
ParseBenchmark.load        1000  avgt    3    1.235 ±  0.011  ms/op
ParseBenchmark.load      100000  avgt    3  177.019 ± 67.098  ms/op
ParseBenchmark.parse       1000  avgt    3    0.894 ±  0.009  ms/op
ParseBenchmark.parse     100000  avgt    3   92.165 ±  4.981  ms/op
```

After
```
Benchmark             (entries)  Mode  Cnt    Score    Error  Units
ParseBenchmark.load        1000  avgt    3    1.080 ±  0.084  ms/op
ParseBenchmark.load      100000  avgt    3  157.310 ±  7.027  ms/op
ParseBenchmark.parse       1000  avgt    3    0.706 ±  0.167  ms/op
ParseBenchmark.parse     100000  avgt    3   74.140 ± 15.403  ms/op
```